### PR TITLE
Update player assets to remote URLs

### DIFF
--- a/public/home/configs/playerCamera.js
+++ b/public/home/configs/playerCamera.js
@@ -4,11 +4,11 @@ export const playerCameraConfig = {
         /* @tweakable Grid spawn position override (grid units) */
         gridPosition: { x: 69, z: 117 },
         /* @tweakable Path to the idle animation GLB */
-        idleGltfPath: 'assets/player/Animation_Idle_02_withSkin.glb',
+        idleGltfPath: 'https://file.garden/Zy7B0LkdIVpGyzA1/Big/home/assets/player/Animation_Idle_02_withSkin.glb',
         /* @tweakable Path to the walking animation GLB */
-        walkGltfPath: 'assets/player/Animation_Walking_withSkin.glb',
+        walkGltfPath: 'https://file.garden/Zy7B0LkdIVpGyzA1/Big/home/assets/player/Animation_Walking_withSkin.glb',
         /* @tweakable Path to the running animation GLB */
-        runGltfPath: 'assets/player/Animation_Running_withSkin.glb',
+        runGltfPath: 'https://file.garden/Zy7B0LkdIVpGyzA1/Big/home/assets/player/Animation_Running_withSkin.glb',
         /* @tweakable Player movement speed in units per second */
         speed: 6.0,
         /* @tweakable Run speed multiplier (applied when holding Shift) */

--- a/public/home/scripts/conversationModal.js
+++ b/public/home/scripts/conversationModal.js
@@ -14,7 +14,7 @@
 export function showConversationModal({
   npcName = '',
   npcImg = 'assets/woman_wastelander/portrait.png',
-  playerImg = 'assets/player/portrait.png',
+  playerImg = 'https://file.garden/Zy7B0LkdIVpGyzA1/Big/home/assets/player/portrait.png',
   onSend = null,
   onClose = null
 } = {}) {

--- a/public/home/scripts/ui/wastelanderConversation.js
+++ b/public/home/scripts/ui/wastelanderConversation.js
@@ -8,7 +8,7 @@ export function showWastelanderConversation(onClose) {
   showConversationModal({
     npcName: 'Wastelander',
     npcImg: '/assets/woman_wastelander/portrait.png',
-    playerImg: '/assets/player/portrait.png',
+    playerImg: 'https://file.garden/Zy7B0LkdIVpGyzA1/Big/home/assets/player/portrait.png',
     onSend: (msg, log, appendToLog) => {
       // Default canned response after delay
       setTimeout(() => appendToLog('Wastelander', '…'), 700);

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -537,5 +537,15 @@ export const mockDevLogs: DevLogEntry[] = [
     author: "Web Team",
     tags: ["footer", "link"],
     imageUrl: "https://robohash.org/devlog-50?size=640x360"
-  }
+  },
+  {
+    id: "devlog-51",
+    title: "Player assets load from CDN",
+    excerpt: "Home Base fetches remote animations and portrait.",
+    content: "playerCamera.js and conversation scripts now reference the File Garden URLs so the command center downloads the player model and portrait on demand.",
+    date: "2025-07-19T00:00:00Z",
+    author: "Web Team",
+    tags: ["assets", "home"],
+    imageUrl: "https://robohash.org/devlog-51?size=640x360"
+  },
 ];


### PR DESCRIPTION
## Summary
- load home base player animations from File Garden
- fetch player portrait from CDN in conversation modal
- updated wastelander conversation to use new portrait URL
- log the change in the DevLog

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684c680bdf4c833283b459c891a723f0