### PR TITLE
Add asset caching script

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,16 @@ This repository contains the web portal for **Remnants of Destruction**. The sit
    ```bash
    npm run fetch-home-assets
    ```
-4. Run the linter:
+4. Cache game assets locally:
+   ```bash
+   npm run cache-assets
+   ```
+5. Run the linter:
    ```bash
    npm run lint
    ```
-   Linting should succeed before submitting pull requests.
-5. Start the development server:
+  Linting should succeed before submitting pull requests.
+6. Start the development server:
    ```bash
    npm run dev
    ```

--- a/cache-server.js
+++ b/cache-server.js
@@ -39,7 +39,7 @@ function serveStatic(filePath, res) {
 
 const server = createServer((req, res) => {
   if (req.method === 'POST' && req.url === '/cache-assets') {
-    const script = join(__dirname, 'public', 'home', 'scripts', 'cache_assets.js');
+    const script = join(__dirname, 'download_and_cache.js');
     execFile('node', [script], err => {
       if (err) {
         res.writeHead(500);

--- a/download_and_cache.js
+++ b/download_and_cache.js
@@ -1,0 +1,58 @@
+// download_and_cache.js
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const ASSETS_FILE = path.join(__dirname, 'public', 'home', 'downloadableassets.txt');
+let assets;
+try {
+  assets = JSON.parse(fs.readFileSync(ASSETS_FILE, 'utf8'));
+} catch (err) {
+  console.error(`❌ Failed to read or parse ${ASSETS_FILE}:`, err);
+  process.exit(1);
+}
+
+function collectUrls(obj, keyPath = [], out = []) {
+  for (const [key, value] of Object.entries(obj)) {
+    if (typeof value === 'string' && /^https?:\/\//.test(value)) {
+      out.push({ keyPath: [...keyPath, key], url: value });
+    } else if (typeof value === 'object' && value !== null) {
+      collectUrls(value, [...keyPath, key], out);
+    }
+  }
+  return out;
+}
+
+const entries = collectUrls(assets);
+
+async function downloadAndCache({ keyPath, url }) {
+  const localPath = path.join(__dirname, 'cache', ...keyPath);
+  const dir = path.dirname(localPath);
+  fs.mkdirSync(dir, { recursive: true });
+
+  if (fs.existsSync(localPath)) {
+    console.log(`🔹 Skipping (cached): ${keyPath.join('/')}`);
+    return;
+  }
+
+  try {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const buffer = await res.arrayBuffer();
+    fs.writeFileSync(localPath, Buffer.from(buffer));
+    console.log(`✅ Saved: ${keyPath.join('/')}`);
+  } catch (err) {
+    console.error(`❌ Error downloading ${url}:`, err.message);
+  }
+}
+
+(async () => {
+  console.log(`Starting download of ${entries.length} assets…`);
+  for (const entry of entries) {
+    await downloadAndCache(entry);
+  }
+  console.log('All done! Your assets live in ./cache/');
+})();

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "fetch-home-assets": "node public/home/scripts/download_assets.js",
+    "cache-assets": "node download_and_cache.js",
     "start": "node cache-server.js"
   },
   "dependencies": {
@@ -49,6 +50,7 @@
     "@turf/intersect": "^7.2.0",
     "@turf/line-split": "^7.2.0",
     "@turf/point-on-feature": "^7.2.0",
+    "@xmldom/xmldom": "^0.9.8",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -548,4 +548,14 @@ export const mockDevLogs: DevLogEntry[] = [
     tags: ["assets", "home"],
     imageUrl: "https://robohash.org/devlog-51?size=640x360"
   },
+  {
+    id: "devlog-52",
+    title: "Asset cache script rewritten",
+    excerpt: "download_and_cache.js saves files under ./cache.",
+    content: "The cache server now calls download_and_cache.js to mirror File Garden assets locally. Run npm run cache-assets to populate the cache directory.",
+    date: "2025-07-20T00:00:00Z",
+    author: "Web Team",
+    tags: ["assets", "script"],
+    imageUrl: "https://robohash.org/devlog-52?size=640x360"
+  },
 ];


### PR DESCRIPTION
## Summary
- add `download_and_cache.js` to cache external assets
- wire cache server to use the new script
- expose `npm run cache-assets` in package.json
- document asset caching in README
- log the change in the devlog

## Testing
- `npm run lint`
- `npm run cache-assets` *(fails: Error downloading due to fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684c8b9a55248332ae45b6e93285744c