### PR TITLE
Add ErrorBoundary wrapper for routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import DevLog from "./pages/DevLog";
 import Media from "./pages/Media";
 import NotFound from "./pages/NotFound";
 import ProtectedRoute from "./components/ProtectedRoute";
+import ErrorBoundary from "./components/ErrorBoundary";
 import { AuthProvider } from "./contexts/AuthContext";
 
 const queryClient = new QueryClient();
@@ -24,21 +25,23 @@ const App = () => (
       <Sonner />
       <BrowserRouter>
         <AuthProvider>
-          <Routes>
-            <Route path="/" element={<Index />} />
-            <Route path="/auth" element={<Auth />} />
-            <Route path="/profile" element={
-              <ProtectedRoute>
-                <Profile />
-              </ProtectedRoute>
-            } />
-            <Route path="/devlog" element={<DevLog />} />
-            <Route path="/game" element={<Game />} />
-            <Route path="/about" element={<AboutMe />} />
-            <Route path="/media" element={<Media />} />
-            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-            <Route path="*" element={<NotFound />} />
-          </Routes>
+          <ErrorBoundary>
+            <Routes>
+              <Route path="/" element={<Index />} />
+              <Route path="/auth" element={<Auth />} />
+              <Route path="/profile" element={
+                <ProtectedRoute>
+                  <Profile />
+                </ProtectedRoute>
+              } />
+              <Route path="/devlog" element={<DevLog />} />
+              <Route path="/game" element={<Game />} />
+              <Route path="/about" element={<AboutMe />} />
+              <Route path="/media" element={<Media />} />
+              {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+          </ErrorBoundary>
         </AuthProvider>
       </BrowserRouter>
     </TooltipProvider>

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,41 @@
+import { Component, ReactNode, ErrorInfo } from "react";
+import { Link } from "react-router-dom";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error("ErrorBoundary caught an error", error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-screen flex items-center justify-center bg-gray-100">
+          <div className="text-center">
+            <h1 className="text-2xl font-bold mb-4">Something went wrong.</h1>
+            <Link to="/" className="text-blue-500 hover:text-blue-700 underline">
+              Return Home
+            </Link>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -537,5 +537,15 @@ export const mockDevLogs: DevLogEntry[] = [
     author: "Web Team",
     tags: ["footer", "link"],
     imageUrl: "https://robohash.org/devlog-50?size=640x360"
+  },
+  {
+    id: "devlog-51",
+    title: "Error boundaries added",
+    excerpt: "App routes now handled safely.",
+    content: "A new ErrorBoundary component wraps the router so unexpected runtime errors show a friendly message and link back home.",
+    date: "2025-07-19T00:00:00Z",
+    author: "Web Team",
+    tags: ["react", "error"],
+    imageUrl: "https://robohash.org/devlog-51?size=640x360"
   }
 ];


### PR DESCRIPTION
## Summary
- create `ErrorBoundary` class component
- wrap router routes with the new boundary
- log errors and show a 'Return Home' link
- record update in devlog

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684d8aedb11c833290bbc9d4bf0168f5